### PR TITLE
Configurable interval

### DIFF
--- a/IoTHubDeviceSimulator/IoTDevice/Device.cs
+++ b/IoTHubDeviceSimulator/IoTDevice/Device.cs
@@ -72,6 +72,7 @@ namespace IoTHubDeviceSimulator.IoTDevice
 
             ConnectionString = connectionString;
             SetNameFromConnectionString();
+            Interval = 5;
         }
 
         private void SetNameFromConnectionString(bool force = false)
@@ -79,6 +80,20 @@ namespace IoTHubDeviceSimulator.IoTDevice
             if (string.IsNullOrEmpty(Name) || force)
             {
                 Name = ConnectionString.Split(';')[1].Replace("DeviceId=", "");
+            }
+        }
+
+        private int _interval;
+        public int Interval
+        {
+            get { return _interval; }
+            set
+            {
+                if (value < 0)
+                    return;
+
+                _interval = value;
+                RaisePropertyChanged(nameof(Interval));
             }
         }
 
@@ -90,7 +105,7 @@ namespace IoTHubDeviceSimulator.IoTDevice
             {
                 _deviceClient = DeviceClient.CreateFromConnectionString(ConnectionString);
             }
-            _timer.Interval = TimeSpan.FromSeconds(5);
+            _timer.Interval = TimeSpan.FromSeconds(Interval);
             _timer.Tick += Timer_Tick;
             _timer.Start();
             RaisePropertyChanged(nameof(IsRunning));

--- a/IoTHubDeviceSimulator/IoTDevice/DeviceEditDialog.xaml
+++ b/IoTHubDeviceSimulator/IoTDevice/DeviceEditDialog.xaml
@@ -18,6 +18,7 @@
     <ContentDialog.Resources>
         <device:NumberFieldsConverter x:Name="NumberFieldsConverter"/>
         <device:ObjectToVisibilityConverter x:Name="ObjectToVisibilityConverter"/>
+        <device:StringToIntConverter x:Name="StringToIntConverter" />
         <DataTemplate x:Key="ListViewItemTemplate" x:DataType="device:Sensor">
             <controls:Expander Header="{x:Bind Name, Mode=OneWay}" Margin="0" HorizontalContentAlignment="Stretch">
                 <StackPanel Margin="12">
@@ -41,6 +42,11 @@
             <StackPanel>
                 <TextBox x:Name="ConnectionStringTb" PlaceholderText="HostName=MyIoTHub.azure-devices.net;..." Header="Connection String" Width="300" Text="{x:Bind Device.ConnectionString, Mode=TwoWay}"></TextBox>
                 <TextBlock x:Name="ErrorTb" Text="Error creating a new IoT Device. Please make sure your Connection String is valid." Visibility="Collapsed" Margin="0 12 0 0" Foreground="Red" TextWrapping="Wrap" Width="300"></TextBlock>
+                <TextBox Header="Interval (in seconds, min is 1 sec)"
+                         Text="{x:Bind Device.Interval, Mode=TwoWay, Converter={StaticResource StringToIntConverter}}"
+                         BeforeTextChanging="IntervalTb_OnBeforeTextChanging"
+                         Visibility="{x:Bind Device, Mode=OneWay, Converter={StaticResource ObjectToVisibilityConverter}}"/>
+
                 <StackPanel Visibility="{x:Bind Device, Mode=OneWay, Converter={StaticResource ObjectToVisibilityConverter}}">
                     <ListView ItemTemplate="{StaticResource ListViewItemTemplate}" ItemsSource="{x:Bind Device.Sensors, Mode=TwoWay}" SelectionMode="None" Margin="0 12 0 12">
                         <ListView.ItemContainerStyle>

--- a/IoTHubDeviceSimulator/IoTDevice/DeviceEditDialog.xaml.cs
+++ b/IoTHubDeviceSimulator/IoTDevice/DeviceEditDialog.xaml.cs
@@ -44,7 +44,7 @@ namespace IoTHubDeviceSimulator.IoTDevice
             }
             catch
             {
-                args.Cancel = true; 
+                args.Cancel = true;
                 ErrorTb.Visibility = Visibility.Visible;
             }
 
@@ -70,6 +70,11 @@ namespace IoTHubDeviceSimulator.IoTDevice
             var b = sender as Button;
             var sensor = b.DataContext as Sensor;
             Device.Sensors.Remove(sensor);
+        }
+
+        private void IntervalTb_OnBeforeTextChanging(TextBox sender, TextBoxBeforeTextChangingEventArgs args)
+        {
+            args.Cancel = args.NewText.Any(c => !char.IsDigit(c));
         }
     }
 }

--- a/IoTHubDeviceSimulator/IoTDevice/StringToIntConverter.cs
+++ b/IoTHubDeviceSimulator/IoTDevice/StringToIntConverter.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Windows.UI.Xaml.Data;
+
+namespace IoTHubDeviceSimulator.IoTDevice
+{
+    public class StringToIntConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, string language)
+        {
+            return $"{value}";
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, string language)
+        {
+            var incomming = value as string;
+            if (string.IsNullOrWhiteSpace(incomming))
+                return 1;
+            else
+                return int.Parse(incomming);
+        }
+    }
+}

--- a/IoTHubDeviceSimulator/IoTHubDeviceSimulator.csproj
+++ b/IoTHubDeviceSimulator/IoTHubDeviceSimulator.csproj
@@ -142,6 +142,7 @@
     <Compile Include="IoTDevice\NumberFieldsConverter.cs" />
     <Compile Include="IoTDevice\ObjectToVisibilityConverter.cs" />
     <Compile Include="IoTDevice\Sensor.cs" />
+    <Compile Include="IoTDevice\StringToIntConverter.cs" />
     <Compile Include="MainPage.xaml.cs">
       <DependentUpon>MainPage.xaml</DependentUpon>
     </Compile>


### PR DESCRIPTION
After this change messages interval can be configurable.
* Only numbers can be set.
* By default set to 1 sec.
* When the device is first created, it's set to 5 sec.

Result:
![image](https://user-images.githubusercontent.com/8158404/100745414-88285400-33df-11eb-9be3-397a40fa49de.png)
